### PR TITLE
Add note about asset naming convention

### DIFF
--- a/lib/src/interpreter.dart
+++ b/lib/src/interpreter.dart
@@ -95,7 +95,8 @@ class Interpreter {
 
   /// Creates interpreter from a [assetName]
   ///
-  /// Place your `.tflite` file in the assets folder.
+  /// Place your `.tflite` file in the assets folder. Do not include the "assets/"
+  /// directory in assetName.
   ///
   /// Example:
   ///


### PR DESCRIPTION
The `assets/` directory is prepended automatically, so
it shouldn't be included in the `assetName`.