### PR TITLE
Fix link to bazelrc setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Make sure you have required version of bazel installed. (Check TF_MIN_BAZEL_VERS
 
 * **Android**
 
-Configure your workspace for android builds as per [these instructions](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/guide/android.md#configure-workspace-and-bazelrc).
+Configure your workspace for android builds as per [these instructions](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/guide/build_android.md#configure-workspace-and-bazelrc).
 
 For TensorFlow >= v2.2
 


### PR DESCRIPTION
They were moved in [1].

[1] https://github.com/tensorflow/tensorflow/commit/e120054f07a423c32eccb561b613a43d26e38e3f