### PR TITLE
Migrate to package:ffi 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.0 (Feb 26, 2021)
+* Update to Dart 2.12 and package:ffi 1.0.0.
+
 ## 0.5.0 (Jul 17, 2020)
 * Expose interpreter's address
 * Create interpreter by address.

--- a/example/lib/classifier.dart
+++ b/example/lib/classifier.dart
@@ -1,3 +1,4 @@
+// @dart=2.11
 import 'package:flutter/services.dart';
 
 // Import tflite_flutter

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,4 @@
+// @dart=2.11
 import 'package:flutter/material.dart';
 import 'package:tflite_flutter_plugin_example/classifier.dart';
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,42 +21,56 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.13"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.2"
+    version: "1.6.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "2.1.0"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.11"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
@@ -70,14 +84,14 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.9"
+    version: "0.15.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.5"
   csslib:
     dependency: transitive
     description:
@@ -99,20 +113,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.0"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   ffi:
     dependency: transitive
     description:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "1.0.0"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.0"
+    version: "6.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -168,20 +189,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.4"
-  image:
-    dependency: transitive
-    description:
-      name: image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.4"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.0"
   io:
     dependency: transitive
     description:
@@ -195,14 +202,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1+1"
-  json_rpc_2:
-    dependency: transitive
-    description:
-      name: json_rpc_2
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.0"
+    version: "0.6.3"
   logging:
     dependency: transitive
     description:
@@ -216,14 +216,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0"
   mime:
     dependency: transitive
     description:
@@ -231,13 +231,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.6+3"
-  multi_server_socket:
-    dependency: transitive
-    description:
-      name: multi_server_socket
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2"
   node_interop:
     dependency: transitive
     description:
@@ -279,7 +272,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4"
+    version: "1.8.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -300,28 +293,21 @@ packages:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.4"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0+1"
-  petitparser:
-    dependency: transitive
-    description:
-      name: petitparser
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.4.0"
+    version: "1.10.0"
   platform:
     dependency: transitive
     description:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.0.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -335,14 +321,14 @@ packages:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   process:
     dependency: transitive
     description:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.12"
+    version: "4.0.0"
   pub_semver:
     dependency: transitive
     description:
@@ -396,105 +382,105 @@ packages:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.9"
+    version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.5"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.4"
+    version: "1.16.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.19"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.3.14"
   tflite_flutter:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
-  vm_service_client:
-    dependency: transitive
-    description:
-      name: vm_service_client
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.2.6+2"
+    version: "5.5.0"
   watcher:
     dependency: transitive
     description:
@@ -509,13 +495,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
-  xml:
+  webdriver:
     dependency: transitive
     description:
-      name: xml
+      name: webdriver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "2.1.2"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.5"
   yaml:
     dependency: transitive
     description:
@@ -524,5 +517,5 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.7.0 <3.0.0"
-  flutter: ">=1.10.0 <2.0.0"
+  dart: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.12.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -342,7 +342,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "3.0.0"
   shelf:
     dependency: transitive
     description:
@@ -459,7 +459,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.6.0"
   typed_data:
     dependency: transitive
     description:
@@ -518,4 +518,4 @@ packages:
     version: "2.2.0"
 sdks:
   dart: ">=2.12.0-259.9.beta <3.0.0"
-  flutter: ">=1.12.0"
+  flutter: ">=1.26.0-17.6.pre"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the tflite_flutter_plugin plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
 
 dependencies:
   flutter:

--- a/example/test/tflite_flutter_plugin_example_e2e.dart
+++ b/example/test/tflite_flutter_plugin_example_e2e.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'dart:io';
 import 'dart:isolate';
 import 'dart:typed_data';

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -5,6 +5,8 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+// @dart=2.11
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/lib/src/bindings/dlib.dart
+++ b/lib/src/bindings/dlib.dart
@@ -1,3 +1,4 @@
+// @dart=2.11
 import 'dart:ffi';
 import 'dart:io';
 

--- a/lib/src/bindings/types.dart
+++ b/lib/src/bindings/types.dart
@@ -40,11 +40,14 @@ class TFLGpuDelegateOptions extends Struct {
   @Int32()
   int waitType;
 
-  factory TFLGpuDelegateOptions.allocate(
-          bool allowPrecisionLoss, TFLGpuDelegateWaitType waitType) =>
-      allocate<TFLGpuDelegateOptions>().ref
-        ..allowPrecisionLoss = allowPrecisionLoss ? 1 : 0
-        ..waitType = waitType.index;
+  static Pointer<TFLGpuDelegateOptions> allocate(
+      bool allowPrecisionLoss, TFLGpuDelegateWaitType waitType) {
+    final result = calloc<TFLGpuDelegateOptions>();
+    result.ref
+      ..allowPrecisionLoss = allowPrecisionLoss ? 1 : 0
+      ..waitType = waitType.index;
+    return result;
+  }
 }
 
 /// Wraps TfLiteGpuDelegateOptionsV2 for android gpu delegate
@@ -86,18 +89,21 @@ class TfLiteGpuDelegateOptionsV2 extends Struct {
   @Int32()
   int inferencePriority3;
 
-  factory TfLiteGpuDelegateOptionsV2.allocate(
-          bool isPrecisionLossAllowed,
-          TfLiteGpuInferenceUsage inferencePreference,
-          TfLiteGpuInferencePriority inferencePriority1,
-          TfLiteGpuInferencePriority inferencePriority2,
-          TfLiteGpuInferencePriority inferencePriority3) =>
-      allocate<TfLiteGpuDelegateOptionsV2>().ref
-        ..isPrecisionLossAllowed = isPrecisionLossAllowed ? 1 : 0
-        ..inferencePreference = inferencePreference.index
-        ..inferencePriority1 = inferencePriority1.index
-        ..inferencePriority2 = inferencePriority2.index
-        ..inferencePriority3 = inferencePriority3.index;
+  static Pointer<TfLiteGpuDelegateOptionsV2> allocate(
+      bool isPrecisionLossAllowed,
+      TfLiteGpuInferenceUsage inferencePreference,
+      TfLiteGpuInferencePriority inferencePriority1,
+      TfLiteGpuInferencePriority inferencePriority2,
+      TfLiteGpuInferencePriority inferencePriority3) {
+    final result = calloc<TfLiteGpuDelegateOptionsV2>();
+    result.ref
+      ..isPrecisionLossAllowed = isPrecisionLossAllowed ? 1 : 0
+      ..inferencePreference = inferencePreference.index
+      ..inferencePriority1 = inferencePriority1.index
+      ..inferencePriority2 = inferencePriority2.index
+      ..inferencePriority3 = inferencePriority3.index;
+    return result;
+  }
 }
 
 /// Status of a TensorFlowLite function call.

--- a/lib/src/bindings/types.dart
+++ b/lib/src/bindings/types.dart
@@ -1,3 +1,4 @@
+// @dart=2.11
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';

--- a/lib/src/delegates/gpu_delegate.dart
+++ b/lib/src/delegates/gpu_delegate.dart
@@ -50,12 +50,11 @@ class GpuDelegateOptionsV2 {
       TfLiteGpuInferencePriority inferencePriority2,
       TfLiteGpuInferencePriority inferencePriority3) {
     return GpuDelegateOptionsV2._(TfLiteGpuDelegateOptionsV2.allocate(
-            isPrecisionLossAllowed,
-            inferencePreference,
-            inferencePriority1,
-            inferencePriority2,
-            inferencePriority3)
-        .addressOf);
+        isPrecisionLossAllowed,
+        inferencePreference,
+        inferencePriority1,
+        inferencePriority2,
+        inferencePriority3));
   }
 
   factory GpuDelegateOptionsV2.defaultOptions() {
@@ -64,7 +63,7 @@ class GpuDelegateOptionsV2 {
 
   void delete() {
     checkState(!_deleted, message: 'TfLiteGpuDelegateV2 already deleted.');
-    free(_options);
+    calloc.free(_options);
     _deleted = true;
   }
 }

--- a/lib/src/delegates/gpu_delegate.dart
+++ b/lib/src/delegates/gpu_delegate.dart
@@ -1,3 +1,4 @@
+// @dart=2.11
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';

--- a/lib/src/delegates/metal_delegate.dart
+++ b/lib/src/delegates/metal_delegate.dart
@@ -1,3 +1,4 @@
+// @dart=2.11
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';

--- a/lib/src/delegates/metal_delegate.dart
+++ b/lib/src/delegates/metal_delegate.dart
@@ -39,12 +39,12 @@ class GpuDelegateOptions {
   factory GpuDelegateOptions(
       bool allowPrecisionLoss, TFLGpuDelegateWaitType waitType) {
     return GpuDelegateOptions._(
-        TFLGpuDelegateOptions.allocate(allowPrecisionLoss, waitType).addressOf);
+        TFLGpuDelegateOptions.allocate(allowPrecisionLoss, waitType));
   }
 
   void delete() {
     checkState(!_deleted, message: 'TfLiteGpuDelegate already deleted.');
-    free(_options);
+    calloc.free(_options);
     _deleted = true;
   }
 }

--- a/lib/src/interpreter.dart
+++ b/lib/src/interpreter.dart
@@ -1,3 +1,4 @@
+// @dart=2.11
 import 'dart:ffi';
 import 'dart:io';
 import 'dart:typed_data';

--- a/lib/src/interpreter.dart
+++ b/lib/src/interpreter.dart
@@ -237,12 +237,12 @@ class Interpreter {
   /// Resize input tensor for the given tensor index. `allocateTensors` must be called again afterward.
   void resizeInputTensor(int tensorIndex, List<int> shape) {
     final dimensionSize = shape.length;
-    final dimensions = allocate<Int32>(count: dimensionSize);
+    final dimensions = calloc<Int32>(dimensionSize);
     final externalTypedData = dimensions.asTypedList(dimensionSize);
     externalTypedData.setRange(0, dimensionSize, shape);
     final status = tfLiteInterpreterResizeInputTensor(
         _interpreter, tensorIndex, dimensions, dimensionSize);
-    free(dimensions);
+    calloc.free(dimensions);
     checkState(status == TfLiteStatus.ok);
     _inputTensors = null;
     _outputTensors = null;

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -19,9 +19,9 @@ class Model {
 
   /// Loads model from a file or throws if unsuccessful.
   factory Model.fromFile(String path) {
-    final cpath = Utf8.toUtf8(path);
+    final cpath = path.toNativeUtf8();
     final model = tfLiteModelCreateFromFile(cpath);
-    free(cpath);
+    calloc.free(cpath);
     checkArgument(isNotNull(model),
         message: 'Unable to create model from file');
     return Model._(model);
@@ -30,7 +30,7 @@ class Model {
   /// Loads model from a buffer or throws if unsuccessful.
   factory Model.fromBuffer(Uint8List buffer) {
     final size = buffer.length;
-    final ptr = allocate<Uint8>(count: size);
+    final ptr = calloc<Uint8>(size);
     final externalTypedData = ptr.asTypedList(size);
     externalTypedData.setRange(0, buffer.length, buffer);
     final model = tfLiteModelCreateFromBuffer(ptr.cast(), buffer.length);

--- a/lib/src/tensor.dart
+++ b/lib/src/tensor.dart
@@ -1,3 +1,4 @@
+// @dart=2.11
 import 'dart:ffi';
 import 'dart:typed_data';
 

--- a/lib/src/tensor.dart
+++ b/lib/src/tensor.dart
@@ -22,7 +22,7 @@ class Tensor {
   }
 
   /// Name of the tensor element.
-  String get name => Utf8.fromUtf8(tfLiteTensorName(_tensor));
+  String get name => tfLiteTensorName(_tensor).toDartString();
 
   /// Data type of the tensor element.
   TfLiteType get type => tfLiteTensorType(_tensor);
@@ -143,18 +143,18 @@ class Tensor {
   void setTo(Object src) {
     var bytes = _convertObjectToBytes(src);
     var size = bytes.length;
-    final ptr = allocate<Uint8>(count: size);
+    final ptr = calloc<Uint8>(size);
     checkState(isNotNull(ptr), message: 'unallocated');
     final externalTypedData = ptr.asTypedList(size);
     externalTypedData.setRange(0, bytes.length, bytes);
     checkState(tfLiteTensorCopyFromBuffer(_tensor, ptr.cast(), bytes.length) ==
         TfLiteStatus.ok);
-    free(ptr);
+    calloc.free(ptr);
   }
 
   Object copyTo(Object dst) {
     var size = tfLiteTensorByteSize(_tensor);
-    final ptr = allocate<Uint8>(count: size);
+    final ptr = calloc<Uint8>(size);
     checkState(isNotNull(ptr), message: 'unallocated');
     final externalTypedData = ptr.asTypedList(size);
     checkState(
@@ -174,7 +174,7 @@ class Tensor {
     } else {
       obj = _convertBytesToObject(bytes);
     }
-    free(ptr);
+    calloc.free(ptr);
     if (obj is List && dst is List) {
       _duplicateList(obj, dst);
     } else {

--- a/lib/tflite_flutter.dart
+++ b/lib/tflite_flutter.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 /// TensorFlow Lite for Flutter
 library tflite_flutter;
 

--- a/lib/tflite_flutter.dart
+++ b/lib/tflite_flutter.dart
@@ -21,4 +21,4 @@ export 'src/tensor.dart';
 export 'src/util/list_shape_extension.dart';
 
 /// tflite version information.
-String get version => Utf8.fromUtf8(tfLiteVersion());
+String get version => tfLiteVersion().toDartString();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,17 @@
 name: tflite_flutter
 description: TensorFlow Lite Flutter plugin provides easy, flexible and fast Dart API to integrate TFLite models in flutter apps.
-version: 0.5.0
+version: 0.6.0
 homepage: https://github.com/am15h/tflite_flutter_plugin
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
-  flutter: ">=1.12.0 <2.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.26.0-17.6.pre <2.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
   path: ^1.6.2
-  quiver: ^2.0.3
+  quiver: ^3.0.0
   ffi: ^1.0.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   path: ^1.6.2
   quiver: ^2.0.3
-  ffi: ^0.1.3
+  ffi: ^1.0.0
 
 dev_dependencies:
   flutter_test:
@@ -35,7 +35,7 @@ flutter:
         package: com.tfliteflutter.tflite_flutter_plugin
         pluginClass: TfliteFlutterPlugin
       ios:
-        pluginClass: TfliteFlutterPlugin  
+        pluginClass: TfliteFlutterPlugin
 
   # To add assets to your plugin package, add an assets section, like this:
   # assets:


### PR DESCRIPTION
Makes this package compatible with Dart 2.12 and package:ffi 1.0.0.

Tested locally on iPod.