### PR TITLE
Load TF Lite libraries when packaged as MSIX

### DIFF
--- a/lib/src/bindings/dlib.dart
+++ b/lib/src/bindings/dlib.dart
@@ -1,6 +1,8 @@
 import 'dart:ffi';
 import 'dart:io';
 
+import 'package:path/path.dart' as Path;
+
 const Set<String> _supported = {'linux', 'mac', 'win'};
 
 String get binaryName {
@@ -32,10 +34,9 @@ DynamicLibrary tflitelib = () {
     return DynamicLibrary.open('libtensorflowlite_c.so');
   } else if (Platform.isIOS) {
     return DynamicLibrary.process();
-  } else {
-    final binaryPath = Platform.script.resolveUri(Uri.directory('.')).path +
-        'blobs/$binaryName';
-    final binaryFilePath = Uri(path: binaryPath).toFilePath();
-    return DynamicLibrary.open(binaryFilePath);
+  } else {    
+    return DynamicLibrary.open(
+      Directory(Platform.resolvedExecutable).parent.path + '/blobs/${binaryName}'
+    );
   }
 }();


### PR DESCRIPTION
When packaging a windows build as an [MSIX package](https://pub.dev/documentation/msix/latest/), installing it and then running it the application does not find the tensorflowlite-c_`os`.`extension` file.
This PR changes the loading code when running on desktop to allow loading the lib when running inside an MSIX packaged app.

Tested on Windows.