### PR TITLE
feat: Add uint8 byte conversion

### DIFF
--- a/lib/src/util/byte_conversion_utils.dart
+++ b/lib/src/util/byte_conversion_utils.dart
@@ -122,6 +122,11 @@ class ByteConversionUtils {
         list.add(ByteData.view(bytes.buffer).getInt8(i));
       }
       return list.reshape<int>(shape);
+    } else if (tfliteType == TfLiteType.uint8) {
+      for (var i = 0; i < bytes.length; i += 1) {
+        list.add(ByteData.view(bytes.buffer).getUint8(i));
+      }
+      return list.reshape<int>(shape);
     } else if (tfliteType == TfLiteType.int64) {
       for (var i = 0; i < bytes.length; i += 8) {
         list.add(ByteData.view(bytes.buffer).getInt64(i));


### PR DESCRIPTION
Supports models with `TfLiteType.uint8` - e.g. those generated by Google Cloud VertexAI tflite export - and address #141 